### PR TITLE
[OD-426] Updated Contact Us Page for City of Boston

### DIFF
--- a/ckanext/contact/theme/templates/contact/form.html
+++ b/ckanext/contact/theme/templates/contact/form.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
     {{ super() }}
-  <li><a href="{{ h.url_for('contact_form') }}">Contact</a></li>
+  <li><a href="{{ h.url_for('contact_form') }}">General Inquiries</a></li>
 
 {% endblock %}
 

--- a/ckanext/contact/theme/templates/contact/form.html
+++ b/ckanext/contact/theme/templates/contact/form.html
@@ -29,7 +29,7 @@
     <p>
       Questions? Comments? We are always glad to hear from you!
     </p>
- 	  <p>
+    <p>
       If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site.
     </p>
   </div>

--- a/ckanext/contact/theme/templates/contact/form.html
+++ b/ckanext/contact/theme/templates/contact/form.html
@@ -29,7 +29,7 @@
     <p>
       Questions? Comments? We are always glad to hear from you!
     </p>
- 	<p>
+ 	  <p>
       If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site.
     </p>
   </div>

--- a/ckanext/contact/theme/templates/contact/form.html
+++ b/ckanext/contact/theme/templates/contact/form.html
@@ -29,6 +29,9 @@
     <p>
       Questions? Comments? We are always glad to hear from you!
     </p>
+ 	<p>
+      If you have technical questions or feedback on the site, please go to the Help & Feedback located at the footer of the site.
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/ckanext/contact/theme/templates/contact/form.html
+++ b/ckanext/contact/theme/templates/contact/form.html
@@ -9,7 +9,7 @@
 {% block primary_content %}
   <article class="module">
     <div class="module-content">
-      <h1 class="page-heading">Contact us</h1>
+      <h1 class="page-heading">General Inquiries</h1>
 
         {% block contact_form_content %}
             {% include "contact/snippets/form.html" %}
@@ -23,14 +23,14 @@
 <div class="module module-narrow module-shallow">
   <h2 class="module-heading">
     <i class="icon-info-sign"></i>
-    {{ _('Contact Us') }}
+    {{ _('General Inquiries') }}
   </h2>
   <div class="module-content">
     <p>
       Questions? Comments? We are always glad to hear from you!
     </p>
  	<p>
-      If you have technical questions or feedback on the site, please go to the Help & Feedback located at the footer of the site.
+      If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site.
     </p>
   </div>
 </div>

--- a/ckanext/contact/theme/templates/contact/success.html
+++ b/ckanext/contact/theme/templates/contact/success.html
@@ -15,11 +15,14 @@
 <div class="module module-narrow module-shallow">
   <h2 class="module-heading">
     <i class="icon-info-sign"></i>
-    {{ _('Contact Us') }}
+    {{ _('General Inquiries') }}
   </h2>
   <div class="module-content">
     <p>
       Questions? Comments? We are always glad to hear from you!
+    </p>
+    <p>
+      If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site.
     </p>
   </div>
 </div>


### PR DESCRIPTION
[[OD-426] Updated Contact Us Page for City of Boston](https://opengovinc.atlassian.net/secure/RapidBoard.jspa?rapidView=131&projectKey=OD&modal=detail&selectedIssue=OD-426)

Introduction:

This PR is to update City of Boston's Contact Us page, which has been renamed to General Inquiries. The sidebar needed to be updated to include the following line "If you have technical questions or feedback on the site, please go to the Help & Feedback located at the footer of the site."

Changes:

- Updated the sidebar in form.html to include the following text "If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site."
- Updated references of 'Contact Us' strings in form.html to be 'General Inquiries'

Test Procedures:
- Click on "General Inquiries" located inside the footer of your CKAN homepage with the following cob_theme extension enabled
- In the sidebar the following line of text should be visible "If you have technical questions or feedback on the site, please go to the Help & Feedback link located at the footer of the site." 
- All previous strings saying 'Contact' or 'Contact Us' are now 'General Inquiries' 
