### PR TITLE
fix: improve required field message

### DIFF
--- a/ckanext/contact/theme/assets/css/contact.css
+++ b/ckanext/contact/theme/assets/css/contact.css
@@ -1,0 +1,12 @@
+.control-required {
+    font-weight: bold;
+}
+.control-required-message .control-required {
+    padding-left: 1px;
+    padding-right: 1px;
+}
+label .control-required {
+    float: right;
+    padding-left: 2px;
+}
+

--- a/ckanext/contact/theme/assets/webassets.yml
+++ b/ckanext/contact/theme/assets/webassets.yml
@@ -8,3 +8,8 @@ main:
     - scripts/recaptcha_helpers.js
     - modules/modal-contact.js
     - modules/form-contact.js
+
+contact_css:
+  output: ckanext-contact/%(version)s_contact.css
+  contents:
+    - css/contact.css

--- a/ckanext/contact/theme/templates/contact/snippets/form.html
+++ b/ckanext/contact/theme/templates/contact/snippets/form.html
@@ -1,11 +1,12 @@
 {% import 'macros/form.html' as form %}
+{% asset 'ckanext-contact/contact_css' %}
 {% asset 'ckanext-contact/main' %}
 
 {% set recaptcha_v3_key = h.get_recaptcha_v3_key() %}
 {% set recaptcha_v3_action = h.get_recaptcha_v3_action() %}
 
 {% block contact_form %}
-    <form class="contact-form form-horizontal" method="post" data-module="form-contact"
+    <form class="contact-form" method="post" data-module="form-contact"
           data-module-action="{{ recaptcha_v3_action }}" data-module-key="{{ recaptcha_v3_key }}">
 
         {{ form.errors(error_summary) }}
@@ -17,6 +18,11 @@
                         {{ _('Questions? Comments? We are always glad to hear from you!') }}
                     {% endblock %}
                 </legend>
+            {% endblock %}
+            {% block required_message %}
+                <p class="control-required-message">
+                    Fields with asterisks (<span class="control-required">*</span>) are required
+                </p>
             {% endblock %}
             {% block contact_form_fields %}
                 {{ form.input('name', label=_('Your Name'), id='field-name', value=data.name,
@@ -40,8 +46,6 @@
 
         <div class="form-actions">
             {% block contact_form_actions %}
-                {{ form.required_message() }}
-
                 <button class="btn btn-primary save" type="submit" name="save">
                     {{ _('Submit') }}
                 </button>


### PR DESCRIPTION
# Description
Update the message for required fields to `Fields with asterisks (*) are required` and position it at the top of the form.
Add CSS to modify the style of the required asterisks.

<img width="1460" height="640" alt="Screenshot 2026-04-02 at 5 29 03 PM" src="https://github.com/user-attachments/assets/32dfb4a7-f4cc-46ef-9658-05b71f19ac8b" />