### PR TITLE
Fix 500 error on contact form submission when referrer_url is a query parameter

### DIFF
--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -83,7 +83,10 @@ def validate(data_dict):
             error_summary['email'] = 'Email address appears to be invalid'
 
     # clean and validate referrer_url
-    referrer_url = clean_referrer_url(data_dict.get('referrer_url', '').strip())
+    referrer_url_raw = data_dict.get('referrer_url', '')
+    if isinstance(referrer_url_raw, list):
+        referrer_url_raw = referrer_url_raw[0] if referrer_url_raw else ''
+    referrer_url = clean_referrer_url(referrer_url_raw.strip())
     if referrer_url:
         site_url = toolkit.config.get('ckan.site_url', '')
         if site_url and not referrer_url.startswith(site_url):

--- a/ckanext/contact/routes/contact.py
+++ b/ckanext/contact/routes/contact.py
@@ -75,7 +75,7 @@ def form():
 
         # Get the referrer URL from the request
         raw_referrer = (
-            toolkit.request.args.get('referrer_url')
+            toolkit.request.args.get('ref')
             or toolkit.request.referrer
             or ''
         )

--- a/ckanext/contact/tests/unit/test_helpers.py
+++ b/ckanext/contact/tests/unit/test_helpers.py
@@ -8,6 +8,7 @@ from ckanext.contact.routes._helpers import (
     build_subject,
     clean_referrer_url,
     get_dataset_title_from_url,
+    validate,
 )
 
 
@@ -141,6 +142,39 @@ class TestCleanReferrerUrl:
     def test_non_contact_page_with_only_cf_params(self):
         url = 'https://example.com/dataset/foo?__cf_chl_tk=abc'
         assert clean_referrer_url(url) == 'https://example.com/dataset/foo'
+
+
+class TestValidateReferrerUrlListGuard:
+    """Tests for the defensive list-guard on referrer_url in validate()."""
+
+    _base_data = {
+        'name': 'Test User',
+        'email': 'test@example.com',
+        'content': 'Test message',
+    }
+
+    @pytest.mark.ckan_config('ckanext.contact.check_email', 'false')
+    def test_referrer_url_as_list_does_not_crash(self):
+        data_dict = {**self._base_data, 'referrer_url': ['https://example.com/dataset/foo', 'https://example.com/dataset/foo']}
+        with patch('ckanext.contact.routes._helpers.recaptcha.check_recaptcha'):
+            errors, _, _ = validate(data_dict)
+        assert 'referrer_url' not in errors
+        assert data_dict['referrer_url'] == 'https://example.com/dataset/foo'
+
+    @pytest.mark.ckan_config('ckanext.contact.check_email', 'false')
+    def test_referrer_url_as_empty_list_becomes_empty_string(self):
+        data_dict = {**self._base_data, 'referrer_url': []}
+        with patch('ckanext.contact.routes._helpers.recaptcha.check_recaptcha'):
+            validate(data_dict)
+        assert data_dict['referrer_url'] == ''
+
+    @pytest.mark.ckan_config('ckanext.contact.check_email', 'false')
+    def test_referrer_url_as_string_still_works(self):
+        data_dict = {**self._base_data, 'referrer_url': 'https://example.com/dataset/foo'}
+        with patch('ckanext.contact.routes._helpers.recaptcha.check_recaptcha'):
+            errors, _, _ = validate(data_dict)
+        assert 'referrer_url' not in errors
+        assert data_dict['referrer_url'] == 'https://example.com/dataset/foo'
 
 
 class TestGetDatasetTitleFromUrl:

--- a/ckanext/contact/tests/unit/test_helpers.py
+++ b/ckanext/contact/tests/unit/test_helpers.py
@@ -154,6 +154,7 @@ class TestValidateReferrerUrlListGuard:
     }
 
     @pytest.mark.ckan_config('ckanext.contact.check_email', 'false')
+    @pytest.mark.ckan_config('ckan.site_url', 'https://example.com')
     def test_referrer_url_as_list_does_not_crash(self):
         data_dict = {**self._base_data, 'referrer_url': ['https://example.com/dataset/foo', 'https://example.com/dataset/foo']}
         with patch('ckanext.contact.routes._helpers.recaptcha.check_recaptcha'):
@@ -169,6 +170,7 @@ class TestValidateReferrerUrlListGuard:
         assert data_dict['referrer_url'] == ''
 
     @pytest.mark.ckan_config('ckanext.contact.check_email', 'false')
+    @pytest.mark.ckan_config('ckan.site_url', 'https://example.com')
     def test_referrer_url_as_string_still_works(self):
         data_dict = {**self._base_data, 'referrer_url': 'https://example.com/dataset/foo'}
         with patch('ckanext.contact.routes._helpers.recaptcha.check_recaptcha'):

--- a/ckanext/contact/theme/templates/header.html
+++ b/ckanext/contact/theme/templates/header.html
@@ -2,7 +2,7 @@
 
 {% block contact_link %}
     <li>
-      <a href="{{ h.url_for('contact.form', referrer_url=h.full_current_url()) }}" title="{{ _('Contact') }}">
+      <a href="{{ h.url_for('contact.form', ref=h.full_current_url()) }}" title="{{ _('Contact') }}">
         {% if c.userobj %}
           <i class="fas fa fa-envelope"></i>
         {% else %}


### PR DESCRIPTION
# Description
When the contact page is opened via a link like `/contact?referrer_url=...`, submitting the form caused a 500 error (`'list' object has no attribute 'strip'`). The form has no explicit action, so it POSTs back to the current URL — resulting in `referrer_url` appearing in both the query string and the POST body, which CKAN's parse_params returns as a list.

## Changes

- Renamed the URL query parameter from `referrer_url` to `ref` (in header.html and the GET handler in contact.py) so the query param and the hidden form field no longer share a name, eliminating the collision
- Added a defensive list-guard in validate() in _helpers.py to handle the case where `referrer_url` arrives as a list
- Added unit tests covering the list, empty list, and string cases for `referrer_url` in validate()